### PR TITLE
Remove unnecessary <meta> tags

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -3,8 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link type="application/atom+xml" rel="alternate" href="https://jekyllrb.com/feed.xml" />
-  <link rel="alternate" type="application/atom+xml" title="Recent commits to Jekyll’s master branch" href="https://github.com/jekyll/jekyll/commits/master.atom">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Lato:300,300italic,400,400italic,700,700italic,900">
   <link rel="stylesheet" href="https://jekyllrb.com/css/screen.css">
   <link rel="icon" type="image/x-icon" href="https://jekyllrb.com/favicon.ico">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <meta name="generator" content="Jekyll v3.1.2">
   <link type="application/atom+xml" rel="alternate" href="https://jekyllrb.com/feed.xml" />
   <link rel="alternate" type="application/atom+xml" title="Recent commits to Jekyll’s master branch" href="https://github.com/jekyll/jekyll/commits/master.atom">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Lato:300,300italic,400,400italic,700,700italic,900">


### PR DESCRIPTION
This page is not being generated by Jekyll, and I see no reason to link to either the main Jekyll blog feed or the GitHub activity feed from this page.
